### PR TITLE
Add support for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.py[cod]
+*.egg
+*.egg-info
+dist
+build
+eggs
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+
+# Pycharm
+.idea

--- a/pandora/__init__.py
+++ b/pandora/__init__.py
@@ -1,4 +1,4 @@
-'''
+"""
 This is Pandora's box. Don't open it if you cannot live with the
 consequences.
 
@@ -20,9 +20,13 @@ not set yet for the current thread. You can use the dict's get method to
 return a sensible default if the key is not available:
 
 >>> user = box.get('user', AnonymousUser())
-'''
+"""
 
-from UserDict import UserDict
+try:
+    from UserDict import UserDict
+except ImportError:
+    from collections import UserDict
+
 try:
     from threading import local
 except ImportError:
@@ -30,14 +34,14 @@ except ImportError:
 
 
 class Box(UserDict):
-    '''
+    """
     Be aware ... you are about to let all the evil into your application!
 
     ``Box`` is a dict-like object that stores its content in a thread local.
 
     You can use this to store global variables like django's request in a
     context that is only accessible by the current thread.
-    '''
+    """
     def __init__(self):
         self._local = local()
         self.data = self._local.__dict__

--- a/pandora_tests/tests.py
+++ b/pandora_tests/tests.py
@@ -49,7 +49,7 @@ class BoxTests(TestCase):
 
 
 class MultiThreadedTests(TestCase):
-    '''
+    """
     Please contribute a patch if you know how to easily test the multithreaded
     behaviour of pandora's box.
-    '''
+    """

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=[
         'pandora',

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@ from setuptools import setup
 
 
 class UltraMagicString(object):
-    '''
+    """
     Taken from
     http://stackoverflow.com/questions/1162338/whats-the-right-way-to-use-unicode-metadata-in-setup-py
-    '''
+    """
+
     def __init__(self, value):
         self.value = value
 
@@ -25,21 +26,20 @@ class UltraMagicString(object):
 
 
 long_description = UltraMagicString(u'\n\n'.join((
-    file('README.rst').read(),
-    file('CHANGES.rst').read(),
+    open('README.rst').read(),
+    open('CHANGES.rst').read(),
 )))
 
-
 setup(
-    name = 'django-pandora',
-    version = '0.1.0',
-    url = 'https://github.com/gregmuellegger/django-pandora',
-    license = 'BSD',
-    description = "Opening Pandora's box by making django's request object available in a thread local.",
-    long_description = long_description,
-    author = UltraMagicString('Gregor Müllegger'),
-    author_email = 'gregor@muellegger.de',
-    classifiers = [
+    name='django-pandora',
+    version='0.1.0',
+    url='https://github.com/gregmuellegger/django-pandora',
+    license='BSD',
+    description="Opening Pandora's box by making django's request object available in a thread local.",
+    long_description=long_description,
+    author=UltraMagicString('Gregor Müllegger'),
+    author_email='gregor@muellegger.de',
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -49,10 +49,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
-    packages = [
+    packages=[
         'pandora',
     ],
-    install_requires = ['setuptools'],
-    test_suite = 'runtests.runtests',
+    install_requires=['setuptools'],
+    test_suite='runtests.runtests',
 )
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+# Project tox config
+#
+# Run tests with default envlist:
+#   tox -r
+#
+# Run tests with specific python version:
+#   tox -r -e py35
+
+[tox]
+envlist = py{27,34,35,36}
+
+[testenv]
+passenv = LANG
+setenv =
+    DJANGO_SETTINGS_MODULE = settings
+    PYTHONPATH = {toxinidir}
+
+deps =
+    -r{toxinidir}/requirements.txt
+
+commands =
+    django-admin test pandora pandora_tests


### PR DESCRIPTION
Hi,
This adds python3 support and a tox config to run the tests on both python 2 and 3.
